### PR TITLE
Changed useHistory to useNavigate

### DIFF
--- a/src/components/create.js
+++ b/src/components/create.js
@@ -1,10 +1,10 @@
 import React, { useState } from 'react';
 import { Button, Checkbox, Form } from 'semantic-ui-react'
 import axios from 'axios';
-import { useHistory } from 'react-router';
+import { useNavigate } from 'react-router';
 
 export default function Create() {
-    let history = useHistory();
+    let navigate = useNavigate();
     const [firstName, setFirstName] = useState('');
     const [lastName, setLastName] = useState('');
     const [checkbox, setCheckbox] = useState(false);
@@ -15,7 +15,7 @@ export default function Create() {
             lastName,
             checkbox
         }).then(() => {
-            history.push('/read')
+            navigate.push('/read')
         })
     }
     return (

--- a/src/components/update.js
+++ b/src/components/update.js
@@ -1,10 +1,10 @@
 import React, { useState, useEffect } from 'react';
 import { Button, Checkbox, Form } from 'semantic-ui-react'
 import axios from 'axios';
-import { useHistory } from 'react-router';
+import { useNavigate } from 'react-router';
 
 export default function Update() {
-    let history = useHistory();
+    let navigate = useNavigate();
     const [id, setID] = useState(null);
     const [firstName, setFirstName] = useState('');
     const [lastName, setLastName] = useState('');
@@ -23,7 +23,7 @@ export default function Update() {
             lastName,
             checkbox
         }).then(() => {
-            history.push('/read')
+            navigate.push('/read')
         })
     }
     return (


### PR DESCRIPTION
useHistory() has been replaced with useNavigate in react-router-dom v6

[Stackoverflow-Reference](https://stackoverflow.com/questions/62861269/attempted-import-error-usehistory-is-not-exported-from-react-router-dom)